### PR TITLE
close pipes

### DIFF
--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -53,6 +53,31 @@ int has_pipe(t_node *node)
 	return (0);
 }
 
+void close_pipe(t_node *node)
+{
+	t_node *tmp;
+	
+	if (node->prev && node->prev->type == PIPE)
+	{
+		if (tmp->fd[IN] > 2)
+			ft_close(tmp->fd[IN]);
+		if (tmp->fd[OUT] > 2)
+			ft_close(tmp->fd[OUT]);
+	}
+	tmp = node->nxt;
+	while (tmp)
+	{
+		if (tmp->type == PIPE)
+		{
+			if (tmp->fd[IN] > 2)
+				ft_close(tmp->fd[IN]);
+			if (tmp->fd[OUT] > 2)
+				ft_close(tmp->fd[OUT]);
+		}
+		tmp = tmp->nxt;
+	}
+}
+
 void ft_command(t_node *node)
 {
 	pid_t pid;
@@ -65,6 +90,13 @@ void ft_command(t_node *node)
 		g_stat = 0;
 		ft_dup2(node->fd[IN], 0);
 		ft_dup2(node->fd[OUT], 1);
+		close_pipe(node);
+		/* // 
+		if (node->fd[IN] != 0)
+			ft_close(node->fd[IN]);
+		if (node->fd[OUT] != 1)
+			ft_close(node->fd[OUT]);
+		// */
 		if (is_builtin(node))
 			ft_buitlin(MULTI_CMD, node);
 		else
@@ -77,12 +109,6 @@ void ft_command(t_node *node)
 			ft_close(node->fd[IN]);
 		if (node->fd[OUT] != 1)
 			ft_close(node->fd[OUT]);
-		// if (node->prev && node->prev->type == PIPE)
-		// {
-		// 	printf("%d %d\n", node->prev->fd[OUT], node->prev->fd[IN]);
-		// 	close(node->prev->fd[IN]);
-		// 	close(node->prev->fd[OUT]);
-		// }
 	}
 }
 

--- a/srcs/utils/ft_system_call.c
+++ b/srcs/utils/ft_system_call.c
@@ -46,6 +46,7 @@ int	ft_open(char *file, int o_flag, int mode)
 
 void	ft_close(int fd)
 {
+	// printf("close fd : %d\n", fd);
 	if (close(fd) == -1)
 		error_exit("close failed", 1);
 }


### PR DESCRIPTION
cat | ls, cat | cat | ls 명령 실행 시
bash 동작 : ls 종료 후 오른쪽 cat 부터 한번 입력 받으면 종료 (ls가 종료되면 파이프의 read end가 닫히기 때문에 sigpipe 발생 -> 종료)
minishell 동작 : ls 출력 및 종료 후 cat이 무한대기
원인 : lsof로 확인결과 cat을 실행 중인 자식 프로세스에 pipe fd가 닫히지 않은채로 입력 대기 중
해결 : dup2 후 pipe 닫기

여전히 bash와 다른점 : exit status
bash : 0
minishell : 13 (sigpipe)
둘 다 sigpipe로 인해 종료되는 것은 동일하지만 왜인지 bash의 경우 pipestatus에만 sigpipe가 반영되는 듯 합니다