### PR TITLE
Hako

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ READLINE_LIB	:= -lreadline -L$(READLINE_LIB)
 all		:$(NAME)
 
 $(NAME)	:$(OBJS)
-	$(CC) -o $(NAME) main.c $(OBJS) $(READLINE_LIB) $(READLINE_INC)
+	$(CC) -g3 -o $(NAME) main.c $(OBJS) $(READLINE_LIB) $(READLINE_INC)
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(READLINE_INC) -c $< -o $@

--- a/main.c
+++ b/main.c
@@ -16,9 +16,9 @@ int	g_stat;
 
 void	handle_eof_exit(t_env *envp)
 {
-	printf("\033[1A");
-	printf("\033[11C");
-	printf("exit\n");
+	write(1, "\033[1A", 4);
+	write(1, "\033[11C", 5);
+	write(1, "exit\n", 5);
 	free_env_all(envp);
 	exit(g_stat);
 }

--- a/srcs/fd/file_fd.c
+++ b/srcs/fd/file_fd.c
@@ -30,6 +30,8 @@ int	set_input_fd(t_node *head, t_node *file_node)
 	}
 	else
 		file_node->fd[IN] = get_heredoc_fd(file_node);
+	if (g_stat == ETC)
+		free_node_all(head);
 	return (1);
 }
 

--- a/srcs/fd/heredoc_fd.c
+++ b/srcs/fd/heredoc_fd.c
@@ -83,11 +83,11 @@ int	get_heredoc_fd(t_node *node)
 	char	*str;
 
 	here_str = ft_strdup("");
-	signal(SIGINT, heredoc_sig_int);
 	g_stat = 0;
 	fd = open_tmpfile();
 	while (1)
 	{
+		signal(SIGINT, heredoc_sig_int);
 		str = readline("> ");
 		if (g_stat == ETC)
 		{

--- a/srcs/fd/heredoc_fd.c
+++ b/srcs/fd/heredoc_fd.c
@@ -90,7 +90,12 @@ int	get_heredoc_fd(t_node *node)
 	{
 		str = readline("> ");
 		if (g_stat == ETC)
-			break ;
+		{
+			free(str);
+			free(here_str);
+			tmp_files(NULL, DEL);
+			return (0);
+		}
 		if (!str)
 		{
 			cursor_up();

--- a/srcs/fd/heredoc_fd.c
+++ b/srcs/fd/heredoc_fd.c
@@ -72,8 +72,8 @@ static int	get_heredoc_readend(int wrfd, char *here_str)
 
 void	cursor_up(void)
 {
-	printf("\033[1A");
-	printf("\033[2C");
+	write(1, "\033[1A", 4);
+	write(1, "\033[2C", 4);
 }
 
 int	get_heredoc_fd(t_node *node)
@@ -86,9 +86,11 @@ int	get_heredoc_fd(t_node *node)
 	signal(SIGINT, heredoc_sig_int);
 	g_stat = 0;
 	fd = open_tmpfile();
-	while (g_stat != ETC)
+	while (1)
 	{
 		str = readline("> ");
+		if (g_stat == ETC)
+			break ;
 		if (!str)
 		{
 			cursor_up();

--- a/srcs/signals/signal.c
+++ b/srcs/signals/signal.c
@@ -16,8 +16,9 @@ extern int	g_stat;
 
 void	child_sig_int(int signal)
 {
-	if (signal == SIGINT)
-		write(2, "^C\n", 3);
+	if (signal != SIGINT)
+		return ;
+	write(2, "^C\n", 3);
 }
 
 void	sig_int(int signal)
@@ -39,6 +40,13 @@ void	sig_int(int signal)
 
 void	heredoc_sig_int(int signal)
 {
+	struct termios	attributes;
+	struct termios	saved;
+
+	tcgetattr(STDIN_FILENO, &saved);
+	tcgetattr(STDIN_FILENO, &attributes);
+	attributes.c_lflag &= (~ECHOCTL);
+	tcsetattr(STDIN_FILENO, TCSANOW, &attributes);
 	if (signal != SIGINT)
 		return ;
 	ioctl(STDIN_FILENO, TIOCSTI, "\n");

--- a/srcs/utils/token_free.c
+++ b/srcs/utils/token_free.c
@@ -73,9 +73,7 @@ void	free_token_all(t_token *head)
 	{
 		target = tmp;
 		if (target->value)
-		{
 			free(target->value);
-		}
 		tmp = tmp->nxt;
 		free(target);
 	}


### PR DESCRIPTION
heredoc에서 ctrl c 나왔을 때 leak 해결
heredoc에서 ctrl d 했을 때 문자열 씹힘 해결
<< hi cat 실행 후 ctrl c 할 때 ^C 출력, cat | cat 에서의 ^C^C 출력은 ~~일단 개인맥에선 제대로 된다~~ ~~다시 관측된다..~~ 진짜로 해결!

미해결 : heredoc ctrl D 이후 바로 ctrl C 했을 때 개행 출력, 없는 파일을 열려고 할 때 생기는 leak은 아직도 났다 안났다 함

+ 추가적인 문제 : 파일열기를 실패하고 나면 뒤에 파이프 커맨드가 있어도 실행 안됨, sigint나 file open 에러로 g_stat이 1인 경우 그 다음에 오는 모든 redir 명령이 동작 안함
=> g_stat을 사용하는 구조를 좀 바꿔야 할 것 같다
