### PR TITLE
Hako

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ READLINE_LIB	:= -lreadline -L$(READLINE_LIB)
 all		:$(NAME)
 
 $(NAME)	:$(OBJS)
-	$(CC) -g3 -o $(NAME) main.c $(OBJS) $(READLINE_LIB) $(READLINE_INC)
+	$(CC) -fsanitize=address -g -o $(NAME) main.c $(OBJS) $(READLINE_LIB) $(READLINE_INC)
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(READLINE_INC) -c $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ READLINE_LIB	:= -lreadline -L$(READLINE_LIB)
 all		:$(NAME)
 
 $(NAME)	:$(OBJS)
-	$(CC) -fsanitize=address -g -o $(NAME) main.c $(OBJS) $(READLINE_LIB) $(READLINE_INC)
+	$(CC) -g3 -o $(NAME) main.c $(OBJS) $(READLINE_LIB) $(READLINE_INC)
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(READLINE_INC) -c $< -o $@

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -35,6 +35,7 @@
 # define INPUT 5
 # define HEREDOC 6
 # define END 7
+# define FAIL 8
 
 # define GET 0
 # define ADD 1

--- a/srcs/fd/fd.c
+++ b/srcs/fd/fd.c
@@ -17,7 +17,7 @@ t_node	*set_cmd_pipe(t_node *prev, t_node *tmp, t_node *cmd)
 	prev->fd[OUT] = tmp->fd[OUT];
 	if (cmd && cmd->fd[OUT] == 1)
 		cmd->fd[OUT] = tmp->fd[OUT];
-	if (!cmd)
+	if (!cmd || cmd->type == FAIL)
 		close(tmp->fd[OUT]);
 	return (NULL);
 }
@@ -55,7 +55,11 @@ int	set_cmd_fd(t_node *node)
 		if (tmp->type == CMD)
 			cmd = init_cmd(prev, tmp);
 		if (cmd && (tmp->type == INPUT || tmp->type == HEREDOC))
+		{
+			if (tmp->fd[IN] == -1)
+				cmd->type = FAIL;
 			cmd->fd[IN] = tmp->fd[IN];
+		}
 		if (tmp->type == TRUNC || tmp->type == APPEND)
 			set_cmd_output(tmp, cmd);
 		if (prev && tmp->type == PIPE)

--- a/srcs/fd/file_fd.c
+++ b/srcs/fd/file_fd.c
@@ -24,8 +24,8 @@ int	set_input_fd(t_node *head, t_node *file_node)
 			printf("minishell: %s: No such file or directory\n",
 				file_node->cmd[1]);
 			g_stat = ETC;
-			free_node_all(head);
-			return (0);
+			// free_node_all(head);
+			return (1); // 뒤에 파이프 있을 경우 그건 진행해야하니까
 		}
 	}
 	else
@@ -63,13 +63,15 @@ int	set_output_fd(t_node *head, t_node *file_node)
 int	set_separator_fd(t_node *node)
 {
 	t_node	*tmp;
+	int		type;
 
 	tmp = node;
 	while (tmp)
 	{
 		if (tmp->type == INPUT || tmp->type == HEREDOC)
 		{
-			if (set_input_fd(node, tmp) == 0 || g_stat == ETC)
+			type = tmp->type;
+			if (set_input_fd(node, tmp) == 0 || (type == HEREDOC && g_stat == ETC))
 				return (0);
 		}
 		else if (tmp->type == TRUNC || tmp->type == APPEND)


### PR DESCRIPTION
기존 동작 : 없는 파일 input redir 시 에러 출력 후 바로 명령 중단
수정 : 에러 출력 후 명령 수행 계속 진행
```< abc ``` 이후 ```< main.c cat``` 과 같은 명령 수행 시 leak 발생 해결